### PR TITLE
strict_text logging formatter to handle boolean options overrides correctly

### DIFF
--- a/logging/formatter_strict_text.go
+++ b/logging/formatter_strict_text.go
@@ -1,0 +1,37 @@
+package logging
+
+import (
+	mate "github.com/heralight/logrus_mate"
+	"github.com/sirupsen/logrus"
+)
+
+type TextFormatterConfig struct {
+	ForceColors      bool   `json:"force_colors,string"`
+	DisableColors    bool   `json:"disable_colors,string"`
+	DisableTimestamp bool   `json:"disable_timestamp,string"`
+	FullTimestamp    bool   `json:"full_timestamp,string"`
+	TimestampFormat  string `json:"timestamp_format"`
+	DisableSorting   bool   `json:"disable_sorting,string"`
+}
+
+func init() {
+	mate.RegisterFormatter("strict_text", NewTextFormatter)
+}
+
+func NewTextFormatter(options mate.Options) (formatter logrus.Formatter, err error) {
+	conf := TextFormatterConfig{}
+
+	if err = options.ToObject(&conf); err != nil {
+		return
+	}
+
+	formatter = &logrus.TextFormatter{
+		ForceColors:      conf.ForceColors,
+		DisableColors:    conf.DisableColors,
+		DisableTimestamp: conf.DisableTimestamp,
+		FullTimestamp:    conf.FullTimestamp,
+		TimestampFormat:  conf.TimestampFormat,
+		DisableSorting:   conf.DisableSorting,
+	}
+	return
+}

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -98,6 +98,32 @@ logging:
 	assert.Equal(t, logger.Formatter.(*logrus.TextFormatter).DisableTimestamp, true)
 }
 
+func TestOverrideBoolOptionAsString(t *testing.T) {
+	yamlConfig := []byte(`
+logging:
+  level: debug 
+  formatter:
+    name: strict_text
+    options:
+      disable_timestamp: "true"
+`)
+
+	viper.SetConfigType("yaml")
+	err := viper.ReadConfig(bytes.NewBuffer(yamlConfig))
+	assert.NilError(t, err)
+
+	var config logging.Config
+	err = viper.UnmarshalKey("logging", &config)
+	assert.NilError(t, err)
+
+	err = logging.SetLoggerConfig(config)
+	assert.NilError(t, err)
+
+	logger := logging.GetLogger()
+	assert.Equal(t, logger.Level, logrus.DebugLevel, "logging level set to debug via config")
+	assert.Equal(t, logger.Formatter.(*logrus.TextFormatter).DisableTimestamp, true)
+}
+
 func TestSetLoggerConfigForStandardLogger(t *testing.T) {
 	// Not every component would be able to use logging.GetLogger()
 	// This test makes sure the config loaded with viper is also


### PR DESCRIPTION
### Changes 🚀 

Introduce new `strict_text` formatter which replicates [Logrus Mate](https://github.com/gogap/logrus_mate) `text` formatter behaviour with a small difference that every boolean Option **should** be passed as a string. This allows to correctly override logging configuration from Env variables.

To demonstrate the issue assuming the `config.yml`:

```yaml
logging:
  level: debug 
  formatter:
    name: text
```

When application executed with the Env override `LOGGING_FORMATTER_OPTIONS_DISABLE_TIMESTAMP=true` the 
config will be equally represented as:

```yaml
logging:
  level: debug 
  formatter:
    name: text
    options:
      disable_timestamp: "true"
```

Notice, the `disable_timestamp` option which will be of type `interface {} | string` when unmarshalled by `viper`.
The [Logrus Mate](https://github.com/gogap/logrus_mate) `text` formatter cannot handle it and throws an error:

```txt
json: cannot unmarshal string into Go struct field TextFormatterConfig.disable_timestamp of type bool
```

:white_check_mark: Using the new `strict_text` formatter and making sure all logging bool Options are specified as strings will handle any overrides easily:

```yaml
logging:
  level: debug 
  formatter:
    name: strict_text
    options:
      disable_timestamp: "true"
```